### PR TITLE
feat: migrate from SendGrid to MailerSend for transactional emails

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -5,7 +5,7 @@ Backend API for BraxtonDiggs.com portfolio site.
 ## What's here
 
 This directory contains Firebase Cloud Functions that handle:
-- Contact form submissions (sends emails via SendGrid)
+- Contact form submissions (sends emails via MailerSend)
 - Instagram media processing and storage
 - Recipe search functionality
 
@@ -55,7 +55,7 @@ The Angular app automatically connects to the local emulator when running in dev
 ## Configuration
 
 Set these up in Firebase Remote Config:
-- `SENDGRID_API_KEY` - for sending contact emails
+- `MAILERSEND_API_KEY` - for sending contact emails
 - `SERPAPI` - for recipe search functionality
 
 CORS is configured for braxtondiggs.com and localhost development.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,13 +7,13 @@
       "name": "functions",
       "hasInstallScript": true,
       "dependencies": {
-        "@sendgrid/mail": "^8.1.4",
         "axios": "^1.7.7",
         "cors": "^2.8.5",
         "express": "^4.21.1",
         "express-validator": "^7.2.0",
         "firebase-admin": "^13.0.1",
         "firebase-functions": "^6.1.1",
+        "mailersend": "^2.6.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -1710,44 +1710,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@sendgrid/client": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.5.tgz",
-      "integrity": "sha512-Jqt8aAuGIpWGa15ZorTWI46q9gbaIdQFA21HIPQQl60rCjzAko75l3D1z7EyjFrNr4MfQ0StusivWh8Rjh10Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sendgrid/helpers": "^8.0.0",
-        "axios": "^1.8.2"
-      },
-      "engines": {
-        "node": ">=12.*"
-      }
-    },
-    "node_modules/@sendgrid/helpers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
-      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.2.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@sendgrid/mail": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.5.tgz",
-      "integrity": "sha512-W+YuMnkVs4+HA/bgfto4VHKcPKLc7NiZ50/NH2pzO6UHCCFuq8/GNB98YJlLEr/ESDyzAaDr7lVE7hoBwFTT3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@sendgrid/client": "^8.1.5",
-        "@sendgrid/helpers": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=12.*"
-      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.40",
@@ -3524,6 +3486,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3620,6 +3591,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4614,6 +4586,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4890,6 +4885,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -6048,6 +6055,34 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic-unfetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz",
+      "integrity": "sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^3.2.0",
+        "unfetch": "^5.0.0"
+      }
+    },
+    "node_modules/isomorphic-unfetch/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -7165,6 +7200,17 @@
         "lru-cache": "6.0.0"
       }
     },
+    "node_modules/mailersend": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mailersend/-/mailersend-2.6.0.tgz",
+      "integrity": "sha512-YX2Gyc6Wyw4Q4IsJ4np2Reof8nFWQ2OP/yXZTZcGCz4B7B1BOAYs71Kjb1uNRTTfDChP7rzzWBoOaX6iNlvPAg==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "isomorphic-unfetch": "^4.0.0",
+        "qs": "^6.11.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -7364,6 +7410,26 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -9240,6 +9306,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unfetch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/isomorphic-unfetch"
+      ]
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9393,6 +9468,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -10867,32 +10951,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
-    "@sendgrid/client": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.5.tgz",
-      "integrity": "sha512-Jqt8aAuGIpWGa15ZorTWI46q9gbaIdQFA21HIPQQl60rCjzAko75l3D1z7EyjFrNr4MfQ0StusivWh8Rjh10Cg==",
-      "requires": {
-        "@sendgrid/helpers": "^8.0.0",
-        "axios": "^1.8.2"
-      }
-    },
-    "@sendgrid/helpers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
-      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
-      "requires": {
-        "deepmerge": "^4.2.2"
-      }
-    },
-    "@sendgrid/mail": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.5.tgz",
-      "integrity": "sha512-W+YuMnkVs4+HA/bgfto4VHKcPKLc7NiZ50/NH2pzO6UHCCFuq8/GNB98YJlLEr/ESDyzAaDr7lVE7hoBwFTT3Q==",
-      "requires": {
-        "@sendgrid/client": "^8.1.5",
-        "@sendgrid/helpers": "^8.0.0"
-      }
-    },
     "@sinclair/typebox": {
       "version": "0.34.40",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
@@ -12083,6 +12141,11 @@
         "which": "^2.0.1"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -12140,7 +12203,8 @@
     "deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true
     },
     "define-data-property": {
       "version": "1.1.4",
@@ -12865,6 +12929,15 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13054,6 +13127,14 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "forwarded": {
@@ -13781,6 +13862,27 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "isomorphic-unfetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz",
+      "integrity": "sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==",
+      "requires": {
+        "node-fetch": "^3.2.0",
+        "unfetch": "^5.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
+      }
     },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -14619,6 +14721,16 @@
         "lru-cache": "6.0.0"
       }
     },
+    "mailersend": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mailersend/-/mailersend-2.6.0.tgz",
+      "integrity": "sha512-YX2Gyc6Wyw4Q4IsJ4np2Reof8nFWQ2OP/yXZTZcGCz4B7B1BOAYs71Kjb1uNRTTfDChP7rzzWBoOaX6iNlvPAg==",
+      "requires": {
+        "gaxios": "^6.0.0",
+        "isomorphic-unfetch": "^4.0.0",
+        "qs": "^6.11.0"
+      }
+    },
     "make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -14746,6 +14858,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "2.7.0",
@@ -15983,6 +16100,11 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
+    "unfetch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -16080,6 +16202,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -24,13 +24,13 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@sendgrid/mail": "^8.1.4",
     "axios": "^1.7.7",
     "cors": "^2.8.5",
     "express": "^4.21.1",
     "express-validator": "^7.2.0",
     "firebase-admin": "^13.0.1",
     "firebase-functions": "^6.1.1",
+    "mailersend": "^2.6.0",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,4 @@
-import sgMail from '@sendgrid/mail';
+import { MailerSend, EmailParams, Sender, Recipient } from 'mailersend';
 import axios from 'axios';
 import cors from 'cors';
 import express, { Request, Response } from 'express';
@@ -112,24 +112,25 @@ app.post('/mail', mailValidation, async (request: Request, response: Response) =
   }
 
   const template = await remoteConfig.getTemplate();
-  const SENDGRID_API_KEY = (template.parameters.SENDGRID_API_KEY.defaultValue as any).value;
+  const MAILERSEND_API_KEY = (template.parameters.MAILERSEND_API_KEY.defaultValue as any).value;
   const data = matchedData(request);
   const sender = `Name: ${data.name}\nEmail: ${data.email}`;
 
   try {
-    sgMail.setApiKey(SENDGRID_API_KEY);
-    await sgMail.send({
-      from: {
-        email: 'no-reply@braxtondiggs.com',
-        name: 'No-Reply'
-      },
-      subject: data.subject ? data.subject : 'Message from BraxtonDiggs.com',
-      text: `${data.message}\n\n\n${sender}`,
-      to: {
-        email: 'hello@braxtondiggs.com',
-        name: 'Braxton Diggs'
-      }
+    const mailerSend = new MailerSend({
+      apiKey: MAILERSEND_API_KEY,
     });
+
+    const sentFrom = new Sender('no-reply@braxtondiggs.com', 'No-Reply');
+    const recipients = [new Recipient('hello@braxtondiggs.com', 'Braxton Diggs')];
+
+    const emailParams = new EmailParams()
+      .setFrom(sentFrom)
+      .setTo(recipients)
+      .setSubject(data.subject ? data.subject : 'Message from BraxtonDiggs.com')
+      .setText(`${data.message}\n\n\n${sender}`);
+
+    await mailerSend.email.send(emailParams);
     return response.json({ status: true, msg: 'Message sent successfully' });
   } catch (error: any) {
     return response.status(500).json({ error: error.toString() });


### PR DESCRIPTION
Migrates transactional email service from SendGrid to MailerSend for improved deliverability and developer experience.

## Changes
- Replace @sendgrid/mail with mailersend SDK
- Update email service implementation in functions/src/index.ts
- Remove SendGrid dependency from package.json
- Update configuration documentation

## Testing
- TypeScript build passes successfully
- API interface remains unchanged

Closes #55

Generated with [Claude Code](https://claude.ai/code)